### PR TITLE
Implement idle bell for ChatGPT

### DIFF
--- a/chrome-extension/manifest.ts
+++ b/chrome-extension/manifest.ts
@@ -48,15 +48,15 @@ const manifest = {
   },
   content_scripts: [
     {
-      matches: ['http://*/*', 'https://*/*', '<all_urls>'],
+      matches: ['https://chatgpt.com/*'],
       js: ['content/index.iife.js'],
     },
     {
-      matches: ['http://*/*', 'https://*/*', '<all_urls>'],
+      matches: ['https://chatgpt.com/*'],
       js: ['content-ui/index.iife.js'],
     },
     {
-      matches: ['http://*/*', 'https://*/*', '<all_urls>'],
+      matches: ['https://chatgpt.com/*'],
       css: ['content.css'],
     },
   ],

--- a/pages/content/src/index.ts
+++ b/pages/content/src/index.ts
@@ -4,3 +4,47 @@ console.log('content script loaded');
 
 // Shows how to call a function defined in another module
 sampleFunction();
+
+if (location.hostname === 'chatgpt.com') {
+  const audioCtx = new AudioContext();
+  let timerId: number | null = null;
+
+  const playBell = () => {
+    const osc = audioCtx.createOscillator();
+    const gain = audioCtx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = 880;
+    osc.connect(gain);
+    gain.connect(audioCtx.destination);
+    osc.start();
+    osc.stop(audioCtx.currentTime + 0.3);
+  };
+
+  const resetTimer = () => {
+    if (timerId !== null) {
+      clearTimeout(timerId);
+    }
+    timerId = window.setTimeout(() => {
+      playBell();
+      timerId = null;
+    }, 2000);
+  };
+
+  const observe = () => {
+    const target = document.body || document.documentElement;
+    if (!target) return;
+    const observer = new MutationObserver(() => resetTimer());
+    observer.observe(target, {
+      childList: true,
+      subtree: true,
+      characterData: true,
+    });
+    resetTimer();
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', observe);
+  } else {
+    observe();
+  }
+}


### PR DESCRIPTION
## Summary
- observe DOM mutations on chatgpt.com
- ring a bell when content stops updating for 2s
- restrict content scripts to chatgpt.com domain

## Testing
- `pnpm lint` *(fails: unable to download pnpm)*